### PR TITLE
Minor fixes

### DIFF
--- a/brian2modelfitting/fitter.py
+++ b/brian2modelfitting/fitter.py
@@ -558,7 +558,11 @@ class OnlineTraceFitter(Fitter):
 
         # Replace input variable by TimedArray
         output_traces = TimedArray(output.transpose(), dt=dt)
-        self.model = self.model + Equations('total_error : %s' % repr(output.dim**2))
+        output_dim = get_dimensions(output)
+        squared_output_dim = ('1' if output_dim is DIMENSIONLESS
+                              else repr(output_dim**2))
+        error_eqs = Equations('total_error : {}'.format(squared_output_dim))
+        self.model = self.model + error_eqs
 
         # Setup NeuronGroup
         namespace = get_local_namespace(level=level+1)
@@ -587,7 +591,6 @@ class OnlineTraceFitter(Fitter):
 
     def calc_errors(self, metric=None):
         """Calculates error in online fashion.To be used inside optim_iter."""
-        errors = self.simulator.network['neurons'].total_error/int((self.duration-self.t_start)/defaultclock.dt)
         errors = self.neurons.total_error/int((self.duration-self.t_start)/defaultclock.dt)
         errors = mean(errors.reshape((self.n_samples, self.n_traces)), axis=1)
         return array(errors)

--- a/brian2modelfitting/fitter.py
+++ b/brian2modelfitting/fitter.py
@@ -122,7 +122,7 @@ class Fitter(metaclass=abc.ABCMeta):
         if isinstance(model, str):
             model = Equations(model)
         if input_var not in model.identifiers:
-            raise Exception("%s is not an identifier in the model" % input_var)
+            raise NameError("%s is not an identifier in the model" % input_var)
 
         defaultclock.dt = dt
         self.dt = dt
@@ -437,9 +437,9 @@ class TraceFitter(Fitter):
                          param_init)
 
         if output_var not in self.model.names:
-            raise ValueError("%s is not a model variable" % output_var)
+            raise NameError("%s is not a model variable" % output_var)
         if output.shape != input.shape:
-            raise Exception("Input and output must have the same size")
+            raise ValueError("Input and output must have the same size")
 
         output_traces = TimedArray(output.transpose(), dt=dt)
 
@@ -552,9 +552,9 @@ class OnlineTraceFitter(Fitter):
                          param_init)
 
         if output_var not in self.model.names:
-            raise ValueError("%s is not a model variable" % output_var)
+            raise NameError("%s is not a model variable" % output_var)
         if output.shape != input.shape:
-            raise Exception("Input and output must have the same size")
+            raise ValueError("Input and output must have the same size")
 
         # Replace input variable by TimedArray
         output_traces = TimedArray(output.transpose(), dt=dt)

--- a/brian2modelfitting/fitter.py
+++ b/brian2modelfitting/fitter.py
@@ -1,4 +1,6 @@
 import abc
+
+from brian2.units.fundamentalunits import DIMENSIONLESS, get_dimensions
 from numpy import ones, array, arange, concatenate, mean, nanmin, reshape
 from brian2 import (NeuronGroup,  defaultclock, get_device, Network,
                     StateMonitor, SpikeMonitor, ms, device, second,
@@ -144,9 +146,17 @@ class Fitter(metaclass=abc.ABCMeta):
         self.output_var = output_var
         self.model = model
 
+        input_dim = get_dimensions(input)
+        input_dim = '1' if input_dim is DIMENSIONLESS else repr(input_dim)
+        input_eqs = "{} = input_var(t, i % n_traces) : {}".format(input_var,
+                                                                  input_dim)
+        self.model += input_eqs
+
+        input_traces = TimedArray(input.transpose(), dt=dt)
+        self.input_traces = input_traces
+
         # initialization of attributes used later
         self.best_params = None
-        self.input_traces = None
         self.network = None
         self.optimizer = None
         self.metric = None
@@ -431,17 +441,11 @@ class TraceFitter(Fitter):
         if output.shape != input.shape:
             raise Exception("Input and output must have the same size")
 
-        # Replace input variable by TimedArray
         output_traces = TimedArray(output.transpose(), dt=dt)
-        input_traces = TimedArray(input.transpose(), dt=dt)
-        self.model = self.model + Equations(input_var + '= input_var(t, i % n_traces) :\
-                                  ' + "% s" % repr(input.dim))
-
-        self.input_traces = input_traces
 
         # Setup NeuronGroup
         namespace = get_local_namespace(level=level+1)
-        namespace['input_var'] = input_traces
+        namespace['input_var'] = self.input_traces
         namespace['output_var'] = output_traces
         namespace['n_traces'] = self.n_traces
         self.neurons = self.setup_neuron_group(self.n_neurons, namespace)
@@ -493,16 +497,9 @@ class SpikeFitter(Fitter):
                          n_samples, threshold, reset, refractory, method,
                          param_init)
 
-        # Replace input variable by TimedArray
-        input_traces = TimedArray(input.transpose(), dt=dt)
-        self.model = self.model + Equations(input_var + '= input_var(t, i % n_traces) :\
-                                   ' + "% s" % repr(input.dim))
-
-        self.input_traces = input_traces
-
         # Setup NeuronGroup
         namespace = get_local_namespace(level=level+1)
-        namespace['input_var'] = input_traces
+        namespace['input_var'] = self.input_traces
         namespace['n_traces'] = self.n_traces
         self.neurons = self.setup_neuron_group(self.n_neurons, namespace)
 
@@ -561,16 +558,11 @@ class OnlineTraceFitter(Fitter):
 
         # Replace input variable by TimedArray
         output_traces = TimedArray(output.transpose(), dt=dt)
-        input_traces = TimedArray(input.transpose(), dt=dt)
-        self.model = self.model + Equations(input_var + '= input_var(t, i % n_traces) :\
-                                  ' + "% s" % repr(input.dim))
         self.model = self.model + Equations('total_error : %s' % repr(output.dim**2))
-
-        self.input_traces = input_traces
 
         # Setup NeuronGroup
         namespace = get_local_namespace(level=level+1)
-        namespace['input_var'] = input_traces
+        namespace['input_var'] = self.input_traces
         namespace['output_var'] = output_traces
         namespace['n_traces'] = self.n_traces
         self.neurons = self.setup_neuron_group(self.n_neurons, namespace)

--- a/brian2modelfitting/optimizer.py
+++ b/brian2modelfitting/optimizer.py
@@ -21,8 +21,8 @@ def calc_bounds(parameter_names, **params):
         bounds for each parameter
     """
     for param in parameter_names:
-        if (param not in params):
-            raise Exception("Bounds must be set for parameter %s" % param)
+        if param not in params:
+            raise TypeError("Bounds must be set for parameter %s" % param)
 
     bounds = []
     for name in parameter_names:
@@ -131,9 +131,9 @@ class NevergradOptimizer(Optimizer):
 
     def initialize(self, parameter_names, popsize, **params):
         for param in params.keys():
-            if (param not in parameter_names):
-                raise Exception("Parameter %s must be defined as a parameter "
-                                "in the model" % param)
+            if param not in parameter_names:
+                raise ValueError("Parameter %s must be defined as a parameter "
+                                 "in the model" % param)
 
         bounds = calc_bounds(parameter_names, **params)
 
@@ -200,9 +200,9 @@ class SkoptOptimizer(Optimizer):
 
     def initialize(self, parameter_names, popsize, **params):
         for param in params.keys():
-            if (param not in parameter_names):
-                raise Exception("Parameter %s must be defined as a parameter "
-                                "in the model" % param)
+            if param not in parameter_names:
+                raise ValueError("Parameter %s must be defined as a parameter "
+                                 "in the model" % param)
 
         bounds = calc_bounds(parameter_names, **params)
 

--- a/docs_sphinx/examples/base.rst
+++ b/docs_sphinx/examples/base.rst
@@ -19,16 +19,16 @@ TraceFitter
                         dt=0.1*ms,
                         method='exponential_euler',
                         output=out_trace,
-                        n_samples=5,)
+                        n_samples=5)
 
   results, error = fitter.fit(optimizer=n_opt,
                               metric=metric,
-                              callback=True,
+                              callback='text',
                               n_rounds=1,
                               param_init={'v': -65*mV},
-                              gl=[1e-8*siemens*cm**-2 * area, 1e-3*siemens*cm**-2 * area],
-                              g_na=[1*msiemens*cm**-2 * area, 2000*msiemens*cm**-2 * area],
-                              g_kd=[1*msiemens*cm**-2 * area, 1000*msiemens*cm**-2 * area],)
+                              gl=[10*nS*cm**-2 * area, 1*mS*cm**-2 * area],
+                              g_na=[1*mS*cm**-2 * area, 2000*mS*cm**-2 * area],
+                              g_kd=[1*mS*cm**-2 * area, 1000*mS*cm**-2 * area])
 
 
 
@@ -37,10 +37,10 @@ SpikeFitter
 
 .. code:: python
 
-  n_opt = SkoptOptimizer('DE')
+  n_opt = SkoptOptimizer('ET')
   metric = GammaFactor(dt, 60*ms)
 
-  fitter = TraceFitter(model=eqs,
+  fitter = SpikeFitter(model=eqs,
                        input_var='I',
                        dt=0.1*ms,
                        input=inp_traces,
@@ -48,11 +48,10 @@ SpikeFitter
                        n_samples=30,
                        threshold='v > -50*mV',
                        reset='v = -70*mV',
-                       method='exponential_euler',)
+                       method='exponential_euler')
 
   results, error = fitter.fit(n_rounds=2,
                    optimizer=n_opt,
                    metric=metric,
-                   param_init={'v': -70*mV},
                    gL=[20*nS, 40*nS],
                    C = [0.5*nF, 1.5*nF])

--- a/docs_sphinx/examples/base.rst
+++ b/docs_sphinx/examples/base.rst
@@ -38,7 +38,7 @@ SpikeFitter
 .. code:: python
 
   n_opt = SkoptOptimizer('ET')
-  metric = GammaFactor(dt, 60*ms)
+  metric = GammaFactor(dt, delta=2*ms)
 
   fitter = SpikeFitter(model=eqs,
                        input_var='I',

--- a/docs_sphinx/examples/hh_multirun.rst
+++ b/docs_sphinx/examples/hh_multirun.rst
@@ -55,7 +55,7 @@ Then the multiple round optimization can be run with following code:
   g_kd : siemens (constant)
   gl   : siemens (constant)
   Cm   : farad (constant)
-  ''',)
+  ''')
 
   ## Optimization and Metric Choice
   n_opt = NevergradOptimizer()
@@ -66,7 +66,7 @@ Then the multiple round optimization can be run with following code:
                        input=inp_traces*amp, output=out_traces*mV, dt=dt,
                        n_samples=20,
                        param_init={'v': -65*mV},
-                       method='exponential_euler',)
+                       method='exponential_euler')
 
   res, error = fitter.fit(n_rounds=2,
                           optimizer=n_opt, metric=metric,
@@ -74,7 +74,7 @@ Then the multiple round optimization can be run with following code:
                           gl = [1e-09 *siemens, 1e-07 *siemens],
                           g_na = [2e-06*siemens, 2e-04*siemens],
                           g_kd = [6e-07*siemens, 6e-05*siemens],
-                          Cm=[0.1*ufarad*cm**-2 * area, 2*ufarad*cm**-2 * area],)
+                          Cm=[0.1*ufarad*cm**-2 * area, 2*ufarad*cm**-2 * area])
 
   ## Show results
   all_output = fitter.results(format='dataframe')
@@ -88,7 +88,7 @@ Then the multiple round optimization can be run with following code:
                           gl = [1e-09 *siemens, 1e-07 *siemens],
                           g_na = [2e-06*siemens, 2e-04*siemens],
                           g_kd = [6e-07*siemens, 6e-05*siemens],
-                          Cm=[0.1*ufarad*cm**-2 * area, 2*ufarad*cm**-2 * area],)
+                          Cm=[0.1*ufarad*cm**-2 * area, 2*ufarad*cm**-2 * area])
 
 
 To get the results and traces:
@@ -102,17 +102,10 @@ To get the results and traces:
   ## Visualization of the results
   fits = fitter.generate_traces(params=None, param_init={'v': -65*mV})
 
-  fig, ax = plt.subplots(ncols=5, figsize=(20,5))
-  ax[0].plot(out_traces[0].transpose())
-  ax[0].plot(fits[0].transpose()/mV)
+  fig, axes = plt.subplots(ncols=5, figsize=(20,5), sharey=True)
 
-  ax[1].plot(out_traces[1].transpose())
-  ax[1].plot(fits[1].transpose()/mV)
-  ax[2].plot(out_traces[2].transpose())
-  ax[2].plot(fits[2].transpose()/mV)
-  ax[3].plot(out_traces[3].transpose())
-  ax[3].plot(fits[3].transpose()/mV)
-  ax[4].plot(out_traces[4].transpose())
-  ax[4].plot(fits[4].transpose()/mV)
+  for ax, data, fit in zip(axes, out_traces, fits):
+      ax.plot(data.transpose())
+      ax.plot(fit.transpose()/mV)
 
   plt.show()

--- a/docs_sphinx/metric/index.rst
+++ b/docs_sphinx/metric/index.rst
@@ -61,10 +61,29 @@ trace. It is calculcated according to:
 
 :math:`2 \Delta N_{exp}r_{exp}` - expected number of coincidences with a Poission process
 
-For more details on the gamma factor, see
-`Jolivet et al. 2008, “A benchmark test for a quantitative assessment of simple
-neuron models”, J. Neurosci. Methods.
-<https://doi.org/10.1016/j.jneumeth.2007.11.006>`_
+For more details on the gamma factor, see:
+
+* `Jolivet et al. 2008, “A benchmark test for a quantitative assessment of simple
+  neuron models”, J. Neurosci. Methods.
+  <https://doi.org/10.1016/j.jneumeth.2007.11.006>`_
+* `Clopath et al. 2007, “Predicting neuronal activity with simple models of the
+  threshold type: adaptive exponential integrate-and-fire model with two
+  compartments.”, Neurocomp
+  <https://doi.org/10.1016/j.neucom.2006.10.047>`_
+
+The coincidence factor :math:`\Gamma` is 1 if the two spike trains match exactly
+and lower otherwise. It is 0 if the number of coincidences matches the number
+expected from two homogeneous Poisson processes of the same rate. To turn the
+coincidence factor into an error term (that is lower for better matches), two
+options are offered. With the ``rate_correction`` option (used by default), the
+error term used is
+:math:`2\frac{\lvert r_\mathrm{data} - r_\mathrm{model}\rvert}{r_\mathrm{data}} - \Gamma`,
+with :math:`r_\mathrm{data}` and :math:`r_\mathrm{model}` being the firing rates
+in the data/model. This is useful because the coincidence factor :math:`\Gamma`
+on its own can give high values (low errors) if the model generates many more
+spikes than were observed in the data; this is penalized by the above term. If
+``rate_correction`` is set to ``False``, :math:`1 - \Gamma` is used as the
+error.
 
 Upon initialization the user has to specify the :math:`\Delta` value, defining
 the maximal tolerance for spikes to be considered coincident:

--- a/docs_sphinx/metric/index.rst
+++ b/docs_sphinx/metric/index.rst
@@ -90,7 +90,7 @@ the maximal tolerance for spikes to be considered coincident:
 
 .. code:: python
 
-  metric = GammaFactor(delta=10*ms)
+  metric = GammaFactor(delta=2*ms)
 
 .. warning::
     The ``delta`` parameter has to be smaller than the smallest inter-spike


### PR DESCRIPTION
One not so minor fix concerns the gamma factor, which seemed to have done the correction for rates incorrectly. The line used:
https://github.com/brian-team/brian2modelfitting/blob/3175648737683de4d25b0d4fd5bf06cc9c3e88eb/brian2modelfitting/metric.py#L71

Which includes the gamma factor in the `2*abs(...)`, where it should rather look like this:

![image](https://user-images.githubusercontent.com/1381982/65521760-063ec000-deea-11e9-989a-6eb30a1f3884.png)

I wonder how our examples worked :smile: (I guess we were in a regime where the total error was positive so that the `abs(...)` did not come into play -- or maybe this bug simply prevented us from getting better fits?)