### PR TITLE
[MRG] Avoid DeprecationWarning when importing skopt/sklearn

### DIFF
--- a/brian2modelfitting/optimizer.py
+++ b/brian2modelfitting/optimizer.py
@@ -1,10 +1,17 @@
 import abc
-from numpy import array, all, ndarray
-from brian2 import asarray
+from numpy import array, all, ndarray, asarray
+import warnings
 
+# Prevent sklearn from adding a filter by monkey-patching the warnings module
+# TODO: Remove when we depend on a newer version of scikit-learn (with
+#       https://github.com/scikit-learn/scikit-learn/pull/15080 merged)
+_filterwarnings = warnings.filterwarnings
+warnings.filterwarnings = lambda *args, **kwds: None
 from skopt.space import Real
 from skopt import Optimizer as skoptOptimizer
 from sklearn.base import RegressorMixin
+warnings.filterwarnings = _filterwarnings
+
 from nevergrad import instrumentation as inst
 from nevergrad.optimization import optimizerlib, registry
 


### PR DESCRIPTION
With somewhat ugly monkey-patching of the `warnings` module, we can prevent scikit-learn's call to `warnings.filterwarnings` having any effect. This will mean that users will not see a `DeprecationWarning` about the `joblib` import in `scikit-optimize`. Note that all this will become unnecessary after the merge of scikit-learn/scikit-learn#15080.