### PR TITLE
Do not use Nevergrad recommendation by default

### DIFF
--- a/brian2modelfitting/fitter.py
+++ b/brian2modelfitting/fitter.py
@@ -142,7 +142,6 @@ class Fitter(metaclass=abc.ABCMeta):
         defaultclock.dt = dt
         self.dt = dt
 
-        self.results_, self.errors = [], []
         self.simulator = setup_fit()
 
         self.parameter_names = model.parameter_names
@@ -244,8 +243,6 @@ class Fitter(metaclass=abc.ABCMeta):
         errors = self.calc_errors(metric)
 
         optimizer.tell(parameters, errors)
-        self.results_.append(parameters)
-        self.errors.append(errors)
 
         results = optimizer.recommend()
 
@@ -301,7 +298,6 @@ class Fitter(metaclass=abc.ABCMeta):
                 raise Exception("You can not change the optimizer between fits")
 
         if self.optimizer is None or restart is True:
-            self.results_, self.errors = [], []
             optimizer.initialize(self.parameter_names, popsize=self.n_samples,
                                  **params)
 
@@ -318,7 +314,7 @@ class Fitter(metaclass=abc.ABCMeta):
 
             # create output variables
             self.best_params = make_dic(self.parameter_names, best_params)
-            error = nanmin(self.errors)
+            error = nanmin(self.optimizer.errors)
 
             if callback(parameters, errors, best_params, error, index) is True:
                 break
@@ -346,10 +342,10 @@ class Fitter(metaclass=abc.ABCMeta):
         names = list(self.parameter_names)
         names.append('errors')
 
-        params = array(self.results_)
+        params = array(self.optimizer.tested_parameters)
         params = params.reshape(-1, params.shape[-1])
 
-        errors = array([array(self.errors).flatten()])
+        errors = array([array(self.optimizer.errors).flatten()])
         data = concatenate((params, errors.transpose()), axis=1)
         dim = self.model.dimensions
 

--- a/brian2modelfitting/tests/test_modelfitting_spikefitter.py
+++ b/brian2modelfitting/tests/test_modelfitting_spikefitter.py
@@ -81,7 +81,7 @@ def test_get_spikes(setup_spikes):
 
 def test_spikefitter_init(setup):
     dt, sf = setup
-    attr_fitter = ['dt', 'results_', 'simulator', 'parameter_names', 'n_traces',
+    attr_fitter = ['dt', 'simulator', 'parameter_names', 'n_traces',
                    'duration', 'n_neurons', 'n_samples', 'method', 'threshold',
                    'reset', 'refractory', 'input', 'output', 'output_var',
                    'best_params', 'input_traces', 'model', 'optimizer',

--- a/brian2modelfitting/tests/test_modelfitting_tracefitter.py
+++ b/brian2modelfitting/tests/test_modelfitting_tracefitter.py
@@ -109,7 +109,7 @@ def test_get_param_dic():
 
 def test_tracefitter_init(setup):
     dt, tf = setup
-    attr_fitter = ['dt', 'results_', 'simulator', 'parameter_names', 'n_traces',
+    attr_fitter = ['dt', 'simulator', 'parameter_names', 'n_traces',
                    'duration', 'n_neurons', 'n_samples', 'method', 'threshold',
                    'reset', 'refractory', 'input', 'output', 'output_var',
                    'best_params', 'input_traces', 'model', 'optimizer',
@@ -330,7 +330,7 @@ def test_fitter_results(setup):
 # OnlineTraceFitter
 def test_onlinetracefitter_init(setup_online):
     dt, otf = setup_online
-    attr_fitter = ['dt', 'results_', 'simulator', 'parameter_names', 'n_traces',
+    attr_fitter = ['dt', 'simulator', 'parameter_names', 'n_traces',
                    'duration', 'n_neurons', 'n_samples', 'method', 'threshold',
                    'reset', 'refractory', 'input', 'output', 'output_var',
                    'best_params', 'input_traces', 'model', 'optimizer',


### PR DESCRIPTION
As discussed in #16, by default we now simply return the best result obtained so far instead of asking Nevergrad for its recommendation (which has numerical issues, see #16). This is handled by an option that allows to switch back to the previous behaviour, which might be useful for stochastic simulations.