### PR TITLE
[MRG] TraceFitter.refine with calculated gradient

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,5 @@ script:
   - pytest --cov=brian2modelfitting
 
 after_success:
+  - if: env(python) = 3.6
   - travis_retry coveralls
-  if: env(python) = 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,6 @@ script:
   - pytest --cov=brian2modelfitting
 
 after_success:
-  - if ["$python" == "3.6"]; then
+  - if [ "$python" == "3.6" ]; then
     travis_retry coveralls;
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,7 @@ install:
 # command to run tests
 script:
   - pytest --cov=brian2modelfitting
-  - coveralls
+
+after_success:
+  - travis_retry coveralls
+  if: env(python) = 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,6 @@ script:
   - pytest --cov=brian2modelfitting
 
 after_success:
-  - if: env(python) = 3.6
-  - travis_retry coveralls
+  - if ["$python" == "3.6"]; then
+    travis_retry coveralls;
+  fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 dist: xenial
+os: linux
 language: python
 python:
   - "3.6"
@@ -17,4 +18,4 @@ script:
 after_success:
   - if [ "$python" == "3.6" ]; then
     travis_retry coveralls;
-  fi
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,6 @@ script:
   - pytest --cov=brian2modelfitting
 
 after_success:
-  - if [ "$python" == "3.6" ]; then
+  - if [ "$TRAVIS_PYTHON_VERSION" == "3.6" ]; then
     travis_retry coveralls;
     fi

--- a/brian2modelfitting/fitter.py
+++ b/brian2modelfitting/fitter.py
@@ -620,7 +620,7 @@ class Fitter(metaclass=abc.ABCMeta):
             fits = get_spikes(self.simulator.monitor,
                               1, self.n_traces)[0]  # a single "sample"
         else:
-            fits = getattr(self.simulator.monitor, output_var)
+            fits = getattr(self.simulator.monitor, output_var)[:]
 
         return fits
 

--- a/brian2modelfitting/fitter.py
+++ b/brian2modelfitting/fitter.py
@@ -143,7 +143,6 @@ def get_sensitivity_equations(group, parameters, namespace=None, level=1,
                 # Check if the equation stays at zero if initialized at zero
                 zeroed = eq.subs(name, sympy.S.Zero)
                 if zeroed == sympy.S.Zero:
-                    print(f'removing {sympy_to_str(name)} from equations')
                     # No need to include equation as differential equation
                     if unit == '1':
                         new_eqs.append(f'{sympy_to_str(name)} = 0 : {unit}')

--- a/brian2modelfitting/fitter.py
+++ b/brian2modelfitting/fitter.py
@@ -94,7 +94,7 @@ def get_sensitivity_equations(group, parameters, namespace=None, level=1):
     sensitivity = []
     sensitivity_names = []
     for parameter in parameters:
-        F = system.jacobian([parameter])
+        F = system.jacobian([str_to_sympy(parameter)])
         names = [str_to_sympy(f'S_{diff_eq_name}_{parameter}')
                  for diff_eq_name in diff_eq_names]
         sensitivity.append(J * Matrix(names) + F)

--- a/brian2modelfitting/fitter.py
+++ b/brian2modelfitting/fitter.py
@@ -805,13 +805,14 @@ class TraceFitter(Fitter):
         errors = []
         def _callback_wrapper(params, iter, resid, *args, **kwds):
             error = mean(resid**2)
-            params =  {p: float(val) for p, val in params.items()}
+            params = {p: float(val) for p, val in params.items()}
             tested_parameters.append(params)
             errors.append(error)
             best_idx = argmin(errors)
             best_error = errors[best_idx]
             best_params = tested_parameters[best_idx]
-            return callback_func(params, errors, best_params, best_error, iter)
+            return callback_func(params, array(errors),
+                                 best_params, best_error, iter)
 
         assert 'Dfun' not in kwds
         if calc_gradient:

--- a/brian2modelfitting/fitter.py
+++ b/brian2modelfitting/fitter.py
@@ -342,6 +342,10 @@ class Fitter(metaclass=abc.ABCMeta):
 
         network = Network(neurons, monitor)
 
+        if calc_gradient:
+            param_init = dict(param_init)
+            param_init.update(get_sensitivity_init(neurons, self.parameter_names,
+                                                   param_init))
         simulator.initialize(network, param_init, name=network_name)
         return simulator
 

--- a/brian2modelfitting/fitter.py
+++ b/brian2modelfitting/fitter.py
@@ -582,12 +582,13 @@ class TraceFitter(Fitter):
             calculation. If not set, will reuse the `t_start` value from the
             previously used metric.
         normalization : float, optional
-            A normalization factor that will be multiplied with the total error
-            before handing it to the optimization algorithm. Can be useful if
-            the algorithm makes assumptions about the scale of errors, e.g. if
-            the size of steps in the parameter space depends on the absolute
-            value of the error. If not set, will reuse the `normalization` value
-            from the previously used metric.
+            A normalization term that will be used rescale results before
+            handing them to the optimization algorithm. Can be useful if the
+            algorithm makes assumptions about the scale of errors, e.g. if the
+            size of steps in the parameter space depends on the absolute value
+            of the error. The difference between simulated and target traces
+            will be divided by this value. If not set, will reuse the
+            `normalization` value from the previously used metric.
         callback: `str` or `~typing.Callable`
             Either the name of a provided callback function (``text`` or
             ``progressbar``), or a custom feedback function
@@ -635,6 +636,8 @@ class TraceFitter(Fitter):
             t_start = getattr(self.metric, 't_start', 0*second)
         if normalization is None:
             normalization = getattr(self.metric, 'normalization', 1.)
+        else:
+            normalization = 1/normalization
 
         callback_func = callback_setup(callback, None)
 

--- a/brian2modelfitting/fitter.py
+++ b/brian2modelfitting/fitter.py
@@ -850,7 +850,7 @@ class TraceFitter(Fitter):
 class SpikeFitter(Fitter):
     def __init__(self, model, input, output, dt, reset, threshold,
                  input_var='I', refractory=False, n_samples=30,
-                 method=None, level=0, param_init=None):
+                 method=None, param_init=None):
         """Initialize the fitter."""
         if method is None:
             method = 'exponential_euler'

--- a/brian2modelfitting/metric.py
+++ b/brian2modelfitting/metric.py
@@ -125,16 +125,16 @@ class Metric(metaclass=abc.ABCMeta):
         t_start : `~brian2.units.fundamentalunits.Quantity`, optional
             Start of time window considered for calculating the fit error.
         normalization : float, optional
-            A normalization factor that will be used before handing results to
-            the optimization algorithm. Can be useful if the algorithm makes
-            assumptions about the scale of errors, e.g. if the size of steps in
-            the parameter space depends on the absolute value of the error.
-            Trace-based metrics multiply the factor with the traces itself,
-            other metrics use it to scale the total error. Not used by default,
-            i.e. defaults to 1.
+            A normalization term that will be used rescale results before
+            handing them to the optimization algorithm. Can be useful if the
+            algorithm makes assumptions about the scale of errors, e.g. if the
+            size of steps in the parameter space depends on the absolute value
+            of the error. Trace-based metrics divide the traces itself by the
+            value, other metrics use it to scale the total error. Not used by
+            default, i.e. defaults to 1.
         """
         self.t_start = t_start
-        self.normalization = normalization
+        self.normalization = 1/normalization
 
     @abc.abstractmethod
     def get_features(self, model_results, target_results, dt):

--- a/brian2modelfitting/simulator.py
+++ b/brian2modelfitting/simulator.py
@@ -127,7 +127,6 @@ class CPPStandaloneSimulator(Simulator):
         super(CPPStandaloneSimulator, self).__init__()
         self.params_init = None
 
-
     def run(self, duration, params, params_names, name='fit'):
         """
         Simulation has to be run in two stages in order to initialize the
@@ -142,7 +141,7 @@ class CPPStandaloneSimulator(Simulator):
                 for k, v in self.var_init.items():
                     self.neurons.__setattr__(k, v)
 
-            network.run(duration, namespace={}, report='text')
+            network.run(duration, namespace={})
         else:
             set_states(self.params_init, params)
             run_again()

--- a/brian2modelfitting/tests/test_metric.py
+++ b/brian2modelfitting/tests/test_metric.py
@@ -62,7 +62,7 @@ def test_calc_mse():
     out = np.ones((3, 10))
     errors = mse.calc(inp, out, 0.01*ms)
     assert_equal(errors, [0, 1])
-    mse = MSEMetric(normalization=2)
+    mse = MSEMetric(normalization=1/2)
     errors = mse.calc(inp, out, 0.01 * ms)
     # The normalization factor scales the traces, so the squared error scales
     # with the square of the normalization factor

--- a/brian2modelfitting/tests/test_metric.py
+++ b/brian2modelfitting/tests/test_metric.py
@@ -140,7 +140,7 @@ def test_get_features_gamma():
     features = gf.get_features(model_spikes, data_spikes, 0.1*ms)
     assert_equal(np.shape(features), (2, 2))
     assert(np.all(np.array(features) > -1))
-    normed_gf = GammaFactor(delta=0.5 * ms, time=10 * ms, normalization=2.)
+    normed_gf = GammaFactor(delta=0.5 * ms, time=10 * ms, normalization=1/2.)
     normed_features = normed_gf.get_features(model_spikes, data_spikes,
                                              0.1 * ms)
     assert_equal(normed_features, 2*features)

--- a/brian2modelfitting/tests/test_modelfitting_spikefitter.py
+++ b/brian2modelfitting/tests/test_modelfitting_spikefitter.py
@@ -7,7 +7,7 @@ from numpy.testing.utils import assert_equal
 from brian2 import (Equations, NeuronGroup, SpikeMonitor, TimedArray,
                     nS, nF, mV, ms, nA, amp, run)
 from brian2modelfitting import (NevergradOptimizer, SpikeFitter, GammaFactor,
-                                Simulator, Metric, Optimizer)
+                                Simulator, Metric, Optimizer, MSEMetric)
 from brian2modelfitting.fitter import get_spikes
 from brian2.devices.device import reinit_devices
 
@@ -101,14 +101,22 @@ def test_spikefitter_init(setup):
     assert isinstance(sf.model, Equations)
 
 
-def test_tracefitter_init_errors(setup):
+def test_spikefitter_init_errors(setup):
     dt, _ = setup
     with pytest.raises(Exception):
         SpikeFitter(model=model, input_var='Exception', dt=dt,
                     input=inp_trace*amp, output=output,
                     n_samples=2,
                     threshold='v > -50*mV',
-                    reset='v = -70*mV',)
+                    reset='v = -70*mV')
+
+    with pytest.raises(ValueError):
+        sf = SpikeFitter(model=model, input_var='I', dt=dt,
+                         input=inp_trace * amp, output=output,
+                         n_samples=2,
+                         threshold='v > -50*mV',
+                         reset='v = -70*mV',
+                         param_init={'V': -70*mV})  # name is "v" not "V"
 
 
 def test_spikefitter_fit(setup):
@@ -132,6 +140,23 @@ def test_spikefitter_fit(setup):
     assert 'C' in results.keys()
 
     assert_equal(results, sf.best_params)
+
+
+def test_spikefitter_fit_errors(setup):
+    dt, sf = setup
+    with pytest.raises(TypeError):
+        results, errors = sf.fit(n_rounds=2,
+                                 optimizer=n_opt,
+                                 metric=MSEMetric(),
+                                 gL=[20*nS, 40*nS],
+                                 C=[0.5*nF, 1.5*nF])
+    with pytest.raises(TypeError):
+        results, errors = sf.fit(n_rounds=2,
+                                 optimizer=None,
+                                 metric=MSEMetric(),
+                                 gL=[20*nS, 40*nS],
+                                 C=[0.5*nF, 1.5*nF])
+
 
 
 def test_spikefitter_param_init(setup):

--- a/brian2modelfitting/tests/test_modelfitting_spikefitter.py
+++ b/brian2modelfitting/tests/test_modelfitting_spikefitter.py
@@ -97,7 +97,6 @@ def test_spikefitter_init(setup):
     for attr in attr_spikefitter:
         assert hasattr(sf, attr)
 
-    assert isinstance(sf.simulator, Simulator)
     assert isinstance(sf.input_traces, TimedArray)
     assert isinstance(sf.model, Equations)
 
@@ -126,7 +125,6 @@ def test_spikefitter_fit(setup):
 
     assert isinstance(sf.metric, Metric)
     assert isinstance(sf.optimizer, Optimizer)
-    assert isinstance(sf.simulator, Simulator)
 
     assert isinstance(results, dict)
     assert isinstance(errors, float)

--- a/brian2modelfitting/tests/test_modelfitting_tracefitter.py
+++ b/brian2modelfitting/tests/test_modelfitting_tracefitter.py
@@ -155,7 +155,6 @@ def test_tracefitter_init(setup):
     for attr in attr_tracefitter:
         assert hasattr(tf, attr)
 
-    assert isinstance(tf.simulator, Simulator)
     assert isinstance(tf.input_traces, TimedArray)
     assert isinstance(tf.model, Equations)
 
@@ -480,7 +479,6 @@ def test_onlinetracefitter_init(setup_online):
     for attr in attr_tracefitter:
         assert hasattr(otf, attr)
 
-    assert isinstance(otf.simulator, Simulator)
     assert isinstance(otf.input_traces, TimedArray)
     assert isinstance(otf.model, Equations)
 
@@ -522,7 +520,6 @@ def test_onlinetracefitter_fit(setup_online):
 
     assert otf.metric is None
     assert isinstance(otf.optimizer, Optimizer)
-    assert isinstance(otf.simulator, Simulator)
 
     assert isinstance(results, dict)
     assert isinstance(errors, float)

--- a/brian2modelfitting/tests/test_modelfitting_tracefitter.py
+++ b/brian2modelfitting/tests/test_modelfitting_tracefitter.py
@@ -281,7 +281,7 @@ def test_fitter_refine_direct(setup):
     # The algorithm is deterministic and should therefore give the same result
     # for the second run
     params, result = tf.refine({'g': 5 * nS}, g=[1 * nS, 30 * nS],
-                               normalization=2)
+                               normalization=1/2)
     assert result.chisqr == 4 * error
 
 

--- a/brian2modelfitting/tests/test_modelfitting_tracefitter.py
+++ b/brian2modelfitting/tests/test_modelfitting_tracefitter.py
@@ -294,7 +294,6 @@ def test_fitter_refine_tstart(setup_constant):
                                t_start=50*dt)
 
     # Fit should be close to 20mV
-    print(params['c'])
     assert np.abs(params['c']*volt - 20*mV) < 1*mV
 
 


### PR DESCRIPTION
Based on discussions with @romainbrette, this PR implements the option for `TraceFitter.refine` to add equations to the model that perform local forward sensitivity analysis and can therefore be used to calculate the gradient of the error function (the basic approach is detailed in [this notebook](https://gist.github.com/mstimberg/f76be93773eaac925e1aa661481ddc09)). This seems to work well and increases the speed of the convergence of the `refine` function. In our tests with real models, it sometimes failed with a division by zero which can be avoided by initializing the responsible variable (e.g. a gating variable) with a value different from zero.

The PR also adds support for standalone mode to `refine` and `generate`, and removes some general limitations of standalone mode (e.g. now it is possible to fit several different models in the same script). 

I think this is ready to merge as it is, or do you still see anything that is missing from this feature @romainbrette ?