### PR TITLE
Support dynamical coupling models

### DIFF
--- a/brian2modelfitting/metric.py
+++ b/brian2modelfitting/metric.py
@@ -266,7 +266,7 @@ class TraceMetric(Metric):
             for fitting. A value of 0 means that data points are ignored. The
             weight values will be normalized so only the relative values matter.
             For example, an array containing 1s, and 2s, will weigh the
-            regions with 2s twice as high (with resepct to the squared error)
+            regions with 2s twice as high (with respect to the squared error)
             as the regions with 1s. Using instead values of 0.5 and 1 would have
             the same effect. Cannot be combined with ``t_start``.
         normalization : float, optional
@@ -286,7 +286,6 @@ class TraceMetric(Metric):
             self.t_weights = normalize_weights(t_weights)
         else:
             self.t_weights = None
-
 
     def calc(self, model_traces, data_traces, dt):
         """

--- a/brian2modelfitting/optimizer.py
+++ b/brian2modelfitting/optimizer.py
@@ -137,7 +137,7 @@ class NevergradOptimizer(Optimizer):
                  **kwds):
         super(Optimizer, self).__init__()
 
-        if method not in list(registry.keys()):
+        if method not in registry:
             raise AssertionError("Unknown to Nevergrad optimization method:"
                                  + method)
         self.tested_parameters = []
@@ -149,7 +149,7 @@ class NevergradOptimizer(Optimizer):
     def initialize(self, parameter_names, popsize, **params):
         self.tested_parameters = []
         self.errors = []
-        for param in params.keys():
+        for param in params:
             if param not in parameter_names:
                 raise ValueError("Parameter %s must be defined as a parameter "
                                  "in the model" % param)
@@ -159,9 +159,9 @@ class NevergradOptimizer(Optimizer):
         instruments = []
         for i, name in enumerate(parameter_names):
             assert len(bounds[i]) == 2
-            vars()[name] = inst.var.Array(1).asscalar().bounded(np.array([bounds[i][0]]),
-                                                                np.array([bounds[i][1]]))
-            instruments.append(vars()[name])
+            instrumentation = inst.var.Array(1).asscalar().bounded(np.array([bounds[i][0]]),
+                                                                   np.array([bounds[i][1]]))
+            instruments.append(instrumentation)
 
         instrum = inst.Instrumentation(*instruments)
         self.optim = optimizerlib.registry[self.method](instrumentation=instrum,
@@ -239,8 +239,8 @@ class SkoptOptimizer(Optimizer):
 
         instruments = []
         for i, name in enumerate(parameter_names):
-            vars()[name] = Real(*np.asarray(bounds[i]), transform='normalize')
-            instruments.append(vars()[name])
+            instrumentation = Real(*np.asarray(bounds[i]), transform='normalize')
+            instruments.append(instrumentation)
 
         self.optim = skoptOptimizer(
             dimensions=instruments,

--- a/brian2modelfitting/tests/test_modelfitting_spikefitter.py
+++ b/brian2modelfitting/tests/test_modelfitting_spikefitter.py
@@ -126,7 +126,7 @@ def test_spikefitter_fit(setup):
                              metric=metric,
                              gL=[20*nS, 40*nS],
                              C=[0.5*nF, 1.5*nF])
-
+    assert sf.simulator.neurons.iteration == 1
     attr_fit = ['optimizer', 'metric', 'best_params']
     for attr in attr_fit:
         assert hasattr(sf, attr)

--- a/brian2modelfitting/tests/test_modelfitting_tracefitter.py
+++ b/brian2modelfitting/tests/test_modelfitting_tracefitter.py
@@ -245,6 +245,7 @@ def test_fitter_fit(setup):
     attr_fit = ['optimizer', 'metric', 'best_params']
     for attr in attr_fit:
         assert hasattr(tf, attr)
+    assert tf.simulator.neurons.iteration == 1
 
     assert isinstance(tf.metric, Metric)
     assert isinstance(tf.optimizer, Optimizer)
@@ -628,17 +629,44 @@ def test_fit_restart(setup):
                              optimizer=n_opt,
                              metric=metric,
                              g=[1*nS, 30*nS])
+    assert tf.simulator.neurons.iteration == 1
 
     results, errors = tf.fit(n_rounds=2,
                              optimizer=n_opt,
                              metric=metric,
                              g=[1*nS, 30*nS])
+    assert tf.simulator.neurons.iteration == 3
 
     results, errors = tf.fit(n_rounds=2,
                              restart=True,
                              optimizer=n_opt,
                              metric=metric,
                              g=[1*nS, 30*nS])
+    assert tf.simulator.neurons.iteration == 1
+
+
+def test_fit_set_start_iteration(setup):
+    dt, tf = setup
+    results, errors = tf.fit(n_rounds=2,
+                             optimizer=n_opt,
+                             metric=metric,
+                             g=[1 * nS, 30 * nS],
+                             start_iteration=17)
+    assert tf.simulator.neurons.iteration == 18
+
+    results, errors = tf.fit(n_rounds=2,
+                             optimizer=n_opt,
+                             metric=metric,
+                             g=[1 * nS, 30 * nS])
+    assert tf.simulator.neurons.iteration == 20
+
+    results, errors = tf.fit(n_rounds=2,
+                             restart=True,
+                             optimizer=n_opt,
+                             metric=metric,
+                             g=[1 * nS, 30 * nS],
+                             start_iteration=5)
+    assert tf.simulator.neurons.iteration == 6
 
 
 def test_fit_continue_with_generate(setup):
@@ -863,7 +891,7 @@ def test_onlinetracefitter_fit(setup_online):
                               optimizer=n_opt,
                               g=[1*nS, 30*nS],
                               restart=False,)
-    print(otf.best_params)
+    assert otf.simulator.neurons.iteration == 1
     attr_fit = ['optimizer', 'metric', 'best_params']
     for attr in attr_fit:
         assert hasattr(otf, attr)

--- a/brian2modelfitting/tests/test_optimizer.py
+++ b/brian2modelfitting/tests/test_optimizer.py
@@ -90,9 +90,9 @@ def test_ask_nevergrad():
 
 def test_ask_skopt():
     s_opt = SkoptOptimizer()
-    s_opt.initialize(['a', 'b', 'c'], a=[0, 1], b=[0, 2], c=[0, 3], popsize=30)
+    n_samples = 9
+    s_opt.initialize(['a', 'b', 'c'], a=[0, 1], b=[0, 2], c=[0, 3], popsize=n_samples)
 
-    n_samples = np.random.randint(1, 30)
     params = s_opt.ask(n_samples)
     assert_equal(np.shape(params), (n_samples, 3))
 
@@ -123,9 +123,9 @@ def test_tell_nevergrad():
 
 def test_tell_skopt():
     s_opt = SkoptOptimizer()
-    s_opt.initialize(['a', 'b', 'c'], a=[0, 1], b=[0, 2], c=[0, 3], popsize=30)
+    n_samples = 9
+    s_opt.initialize(['a', 'b', 'c'], a=[0, 1], b=[0, 2], c=[0, 3], popsize=n_samples)
 
-    n_samples = np.random.randint(1, 30)
     params = s_opt.ask(n_samples)
 
     errors = np.random.rand(n_samples)
@@ -158,9 +158,9 @@ def test_recommend_nevergrad():
 
 def test_recommend_skopt():
     s_opt = SkoptOptimizer()
-    s_opt.initialize(['a', 'b', 'c'], a=[0, 1], b=[0, 2], c=[0, 3], popsize=30)
+    n_samples = 9
+    s_opt.initialize(['a', 'b', 'c'], a=[0, 1], b=[0, 2], c=[0, 3], popsize=n_samples)
 
-    n_samples = np.random.randint(1, 30)
     params = s_opt.ask(n_samples)
 
     errors = np.random.rand(n_samples)

--- a/brian2modelfitting/tests/test_simulation_runtime.py
+++ b/brian2modelfitting/tests/test_simulation_runtime.py
@@ -25,6 +25,7 @@ model2 = Equations('''
                   I = 20* nA :amp
                   gL: siemens (constant)
                   C: farad (constant)
+                  iteration : integer (constant, shared)
                   ''',
                   EL=-70*mV,
                   VT=-50*mV,
@@ -83,18 +84,6 @@ def test_initialize_simulation_runtime(setup):
     assert_raises(TypeError, rts.initialize, Network)
 
 
-def test_run_simulation_runtime(setup):
-    net, dt, duration = setup
-    start_scope()
-
-    rts = RuntimeSimulator()
-    rts.initialize(net, var_init=None)
-
-    rts.run(duration, {'g': 100, 'E': 10}, ['g', 'E'])
-    I = getattr(rts.statemonitor, 'I')
-    assert_equal(np.shape(I), (1, duration/dt))
-
-
 def test_run_simulation_runtime_var_init(setup):
     _, dt, duration = setup
     start_scope()
@@ -106,6 +95,6 @@ def test_run_simulation_runtime_var_init(setup):
     rts = RuntimeSimulator()
     rts.initialize(net, var_init={'v': -60*mV})
 
-    rts.run(duration, {'gL': 100, 'C': 10}, ['gL', 'C'])
+    rts.run(duration, {'gL': 100, 'C': 10}, ['gL', 'C'], iteration=0)
     v = getattr(rts.statemonitor, 'v')
     assert_equal(np.shape(v), (1, duration/dt))

--- a/brian2modelfitting/tests/test_simulation_standalone.py
+++ b/brian2modelfitting/tests/test_simulation_standalone.py
@@ -23,7 +23,7 @@ model = Equations('''
 empty_net = Network()
 
 
-@pytest.fixture()
+@pytest.fixture
 def setup(request):
     dt = 0.1 * ms
     duration = 10 * ms
@@ -40,14 +40,14 @@ def setup(request):
     return net, dt, duration
 
 
-@pytest.fixture()
+@pytest.fixture
 def setup_standalone(request):
     # Workaround to avoid issues with Network instances still around
     Network.__instances__().clear()
     set_device('cpp_standalone', directory=None)
     dt = 0.1 * ms
     duration = 10 * ms
-    neurons = NeuronGroup(1, model, name='neurons')
+    neurons = NeuronGroup(1, model + Equations('iteration: integer (constant, shared)'), name='neurons')
     monitor = StateMonitor(neurons, 'I', record=True, name='statemonitor')
 
     net = Network(neurons, monitor)
@@ -99,6 +99,6 @@ def test_run_simulation_standalone(setup_standalone):
     sas = CPPStandaloneSimulator()
     sas.initialize(net, var_init=None)
 
-    sas.run(duration, {'g': 100, 'E': 10}, ['g', 'E'])
+    sas.run(duration, {'g': 100, 'E': 10}, ['g', 'E'], iteration=0)
     I = getattr(sas.statemonitor, 'I')
     assert_equal(np.shape(I), (1, duration/dt))


### PR DESCRIPTION
This PR is not ready yet (at the very least it is missing tests and documentation), but I wanted to discuss the approach first. The general idea is to support dynamical coupling of the model to the target variable (#23). But since for now we don't have much experience in what the best approach is (how should the coupling decay over time, how should the error be adapted, etc.), I wanted to first lay the foundation by making "everything" possible. Later, when we are sure about the details, we can add convenient shortcuts.

Since #33, a model can already refer to the target values of a variable `x` as `x_target`. This branch adds two additional functionalities:
* models have access to a variable `iteration`, which simply contains the number of the current iteration
* when fitting, the user can specify an additional "penalty" value that will be added to the total error for a model parametrization. This could be a value (or one value for each sample/trace), but most usefully it can refer to a subexpression defined in the model itself.

With these two mechanisms, one could formulate a model like this:
```Python
eqs = '''dv/dt = ... + k*(v_target - v): volt
k = (10*ms)**-1/(iteration + 1) : second**-1
penalty = (k*ms*mV)**2 : volt**2  # no idea of how what factor to use here
```
The `k` term makes use of the `iteration` variable and scales the coupling as an inverse power law of the iteration (but that could also be `exp(-iteration/something)` or similar of course). When creating the `Fitter`, or during the call to `fit` one then additionally needs to specify `penalty='penalty'` to define which equation defines the penalty term.

There are options to change the start value of the `iteration` variable of a `fit` call so that one can run it again with a very high iteration value and therefore switch off the coupling. The same is done by default for calls to `generate` and also `refine`, because I wasn't sure that this coupling would play well with the gradient-based methods (which assume that running the model with the same parameters always give the same result).

The "high iteration value to switch off coupling" approach feels a bit hacky, but it felt like the most simple. Another approach would have to pass in some boolean variable that could be used with something like `+ int(use_coupling)*k*(v_target - v)` in the equations. One can already do this manually by (ab)using the parameter initialization mechanism.

Again, to be clear: in the long run it could be nice to just have a convenient "use coupling" switch that does all this automatically. For now, I do not want to commit to a specific implementation, though, but just make sure that the model has access to everything that is needed to implement the approach.

 