### PR TITLE
Multiple output var support

### DIFF
--- a/brian2modelfitting/inferencer.py
+++ b/brian2modelfitting/inferencer.py
@@ -592,7 +592,7 @@ class Inferencer(object):
             Sampled prior.
         x : torch.tensor
             Summary statistics.
-        args : list, optional
+        args : tuple, optional
             Contains a uniformly distributed sbi.utils.BoxUniform
             proposal. Used only for SNPE, for SNLE and SNRE,
             ``proposal`` should not be passed to ``append_simulations``
@@ -791,16 +791,16 @@ class Inferencer(object):
             # could provide them by using more flexible inferface via
             # `.infer_step` method
             if inference_method == 'SNPE':
-                args = [prior]
+                args = [prior, ]
             else:
-                args = []
+                args = [None, ]
         else:  # `.infer_step` has been called manually
             x_o = torch.tensor(self.x_o, dtype=torch.float32)
             prior = self.posterior.set_default_x(x_o)
             if self.posterior._method_family == 'snpe':
-                args = [prior]
+                args = [prior, ]
             else:
-                args = []
+                args = [None, ]
 
         # allocate empty list of posteriors
         posteriors = []

--- a/brian2modelfitting/inferencer.py
+++ b/brian2modelfitting/inferencer.py
@@ -425,7 +425,7 @@ class Inferencer(object):
         theta = np.atleast_2d(theta.numpy())
         return theta
 
-    def extract_summary_statistics(self, theta, level=1):
+    def extract_summary_statistics(self, theta, level=0):
         """Return summary statistics for training the neural density
         estimator.
 
@@ -777,7 +777,7 @@ class Inferencer(object):
                 if n_samples is None:
                     raise ValueError('Either provide `x` or `n_samples`.')
                 else:
-                    x = self.extract_summary_statistics(theta)
+                    x = self.extract_summary_statistics(theta, level=1)
             self.x = x
 
             # initialize inference object

--- a/brian2modelfitting/inferencer.py
+++ b/brian2modelfitting/inferencer.py
@@ -277,12 +277,12 @@ class Inferencer(object):
         self.x = None
 
         # observation the focus is on
-        for o in self.output:
+        for ov, o in zip(self.output_var, self.output):
             o = np.array(o)
             if features:
                 obs = []
                 for _o in o:
-                    for feature in features:
+                    for feature in features[ov]:
                         obs.append(feature(_o))
                 x_o = np.array(obs, dtype=np.float32)
             else:
@@ -461,7 +461,7 @@ class Inferencer(object):
                 summary_statistics = []
                 # TODO: should be vectorized
                 for _o in o:
-                    for feature in self.features:
+                    for feature in self.features[ov]:
                         summary_statistics.append(feature(_o))
                 x = np.array(summary_statistics, dtype=np.float32)
                 x = x.reshape(self.n_samples, -1)

--- a/brian2modelfitting/inferencer.py
+++ b/brian2modelfitting/inferencer.py
@@ -726,7 +726,8 @@ class Inferencer(object):
             Inference method. Either of SNPE, SNLE or SNRE.
         density_estimator_model : str, optional
             The type of density estimator to be created. Either
-            ``mdn``, ``made``, ``maf`` or ``nsf``.
+            ``mdn``, ``made``, ``maf``, ``nsf`` for SNPE and SNLE, or
+            ``linear``, ``mlp``, ``resnet`` for SNRE.
         inference_kwargs : dict, optional
             Additional keyword arguments for the inferencer method
             definition.

--- a/examples/IF_sbi.py
+++ b/examples/IF_sbi.py
@@ -1,6 +1,5 @@
 from brian2 import *
 from brian2modelfitting import *
-from scipy.signal import find_peaks
 
 
 # Generate input and output data traces
@@ -23,7 +22,7 @@ neurons = NeuronGroup(1, eqs,
                       threshold='v > -50 * mV',
                       reset='v = -70 * mV',
                       method='exponential_euler')
-neurons.v = -70 * mV
+neurons.v = -70*mV
 neurons.set_states({'gl': 30*nS,
                     'C': 1*nF})
 monitor = StateMonitor(neurons, 'v', record=True)
@@ -49,10 +48,9 @@ inferencer = Inferencer(dt=dt, model=eqs_inf,
                         reset='v = -70 * mV',
                         param_init={'v': -70 * mV})
 
-inferencer.infere(n_samples=10000,
-                  inference_method='SNPE',
-                  gl=[10*nS, 100*nS],
-                  C=[0.1*nF, 10*nF])
+inferencer.infer(n_samples=10_000,
+                 gl=[10*nS, 100*nS],
+                 C=[0.1*nF, 10*nF])
 
 inferencer.sample((10000, ))
 inferencer.pairplot(labels={'gl': r'$\overline{g}_{l}$',

--- a/examples/hh_sbi_flexible_interface.py
+++ b/examples/hh_sbi_flexible_interface.py
@@ -63,12 +63,12 @@ if os.path.exists(path_to_data):
     theta, x = inferencer.load_summary_statistics(path_to_data)
 else:
     # Generate training data
-    theta = inferencer.generate_training_data(n_samples=10_000,
+    theta = inferencer.generate_training_data(n_samples=1000,
                                               prior=prior)
     # Extract summary stats
     x = inferencer.extract_summary_statistics(theta)
     # Save the data for later use
-    inferencer.save_summary_statistics(path_to_data, theta, x)
+    #inferencer.save_summary_statistics(path_to_data, theta, x)
 
 # Amortized inference
 # Training the neural density estimator

--- a/examples/hh_sbi_simple_interface.py
+++ b/examples/hh_sbi_simple_interface.py
@@ -81,7 +81,7 @@ inferencer.conditional_pairplot(condition=condition,
 # Construct and visualize conditional coefficient matrix
 cond_coeff_mat = inferencer.conditional_corrcoeff(condition=condition,
                                                   limits=limits)
-fig, ax = subplots(1,1, figsize=(6, 6))
+fig, ax = subplots(1, 1, figsize=(6, 6))
 im = imshow(cond_coeff_mat, clim=[-1, 1])
 _ = fig.colorbar(im)
 
@@ -97,7 +97,7 @@ for idx in range(ncols):
     axs[0, idx].plot(t, out_traces[idx, :], lw=3, label='measurements')
     axs[0, idx].plot(t, inf_traces[idx, :]/mV, '--', lw=3,label='fits')
     axs[1, idx].plot(t, inp_traces[idx, :]/nA, 'k-', label='stimulus')
-    axs[1, idx].set_xlabel('t, ms')
+    axs[1, idx].set_xlabel('$t$, ms')
     if idx == 0:
         axs[0, idx].set_ylabel('$v$, mV')
         axs[1, idx].set_ylabel('$I$, nA')

--- a/examples/hh_sbi_synthetic_traces.py
+++ b/examples/hh_sbi_synthetic_traces.py
@@ -51,8 +51,8 @@ eqs = '''
     dm/dt = alpham*(1-m) - betam*m : 1
     dn/dt = alphan*(1-n) - betan*n : 1
     dh/dt = alphah*(1-h) - betah*h : 1
-    alpham = (-0.32/mV) * (Vm - VT - 13.*mV) / (exp((-(Vm - VT - 13.*mV))/(4.*mV)) - 1)/ms : Hz
-    betam = (0.28/mV) * (Vm - VT - 40.*mV) / (exp((Vm - VT - 40.*mV)/(5.*mV)) - 1)/ms : Hz
+    alpham = (-0.32/mV) * (Vm - VT - 13.*mV) / (exp((-(Vm - VT - 13.*mV)) / (4.*mV)) - 1)/ms : Hz
+    betam = (0.28/mV) * (Vm - VT - 40.*mV) / (exp((Vm - VT - 40.*mV) / (5.*mV)) - 1)/ms : Hz
     alphah = 0.128 * exp(-(Vm - VT - 17.*mV) / (18.*mV))/ms : Hz
     betah = 4/(1 + exp((-(Vm - VT - 40.*mV)) / (5.*mV)))/ms : Hz
     alphan = (-0.032/mV) * (Vm - VT - 15.*mV) / (exp((-(Vm - VT - 15.*mV)) / (5.*mV)) - 1)/ms : Hz
@@ -71,11 +71,15 @@ inferencer = Inferencer(dt=dt, model=eqs,
                                     'm': '1/(1 + betam/alpham)',
                                     'h': '1/(1 + betah/alphah)',
                                     'n': '1/(1 + betan/alphan)'})
-inferencer.infere(n_samples=10_000,
-                  inference_method='SNPE',
-                  density_estimator_model='mdn',
-                  gNa=[.5*uS, 80.*uS],
-                  gK=[1e-4*uS, 15.*uS])
+
+# Amortized inference
+inferencer.infer(n_samples=10_000,
+                 inference_method='SNPE',
+                 density_estimator_model='mdn',
+                 gNa=[.5*uS, 80.*uS],
+                 gK=[1e-4*uS, 15.*uS])
+
+# Sample from posterior
 inferencer.sample((10_000, ))
 
 # Visualize estimated posterior distribution
@@ -83,8 +87,8 @@ inferencer.pairplot(limits={'gNa': [.5*uS, 80.*uS],
                             'gK': [1e-4*uS, 15.*uS]},
                     ticks={'gNa': [.5*uS, 80.*uS],
                            'gK': [1e-4*uS, 15.*uS]},
-                    labels={'gNa': r'$\overline{g}_{Na}$',
-                            'gK': r'$\overline{g}_{K}$'},
+                    labels={'gNa': r'$\overline{g}_\mathrm{Na}$',
+                            'gK': r'$\overline{g}_\mathrm{K}$'},
                     points={'gNa': 32*uS,
                             'gK': 1*uS},
                     points_offdiag={'markersize': 6},
@@ -103,5 +107,4 @@ axs[0].legend()
 axs[1].plot(t, I_inj.ravel()/nA, 'k-', label='stimulus')
 axs[1].set(xlabel='t, ms', ylabel='I, nA')
 axs[1].legend()
-
 show()


### PR DESCRIPTION
Resolves #53.

This PR introduces slight changes in API: instead of providing list of functions that will be used to extract relevant features from the simulated traces, the dictionary should be provided instead. Keys should be names of output variables as defined in the model equations, while values should be lists (with the same number of elements) where each element of the list is callable that returns a summary feature.
So instead of:
```python
inferencer = Inferencer(dt=dt, model=eqs,
                        input={'I': inp_traces*amp},
                        output={'v': out_traces*mV},
                        features=[lambda x: x[(t > 5) & (t < 10)].mean(),
                                  lambda x: x[(t > 5) & (t < 10)].std(),
                                  lambda x: x.max()],
                        method='exponential_euler',
                        threshold='m > 0.5',
                        refractory='m > 0.5',
                        param_init={'v': 'VT'})
```
goes:
```python
inferencer = Inferencer(dt=dt, model=eqs,
                        input={'I': inp_traces*amp},
                        output={'v': out_traces*mV},
                        features={'v': [lambda x: x[(t > 5) & (t < 10)].mean(),
                                        lambda x: x[(t > 5) & (t < 10)].std(),
                                        lambda x: x.max()]},
                        method='exponential_euler',
                        threshold='m > 0.5',
                        refractory='m > 0.5',
                        param_init={'v': 'VT'})
```
This enables the user to simultaneously infer unknown parameters from different output variables.

Additional updates:
- docstrings typos are fixed;
- the relevant examples are aligned with the changes in the API ;
- default `level` value in some function in `Inferencer` are now changed, so the user should not have to worry about namespaces even when using a flexible interface, i.e., when using `infer_step` method manually.