### PR TITLE
Fix ImportError: Replace removed NaN with nan for NumPy 2.x compatibi…

### DIFF
--- a/brian2modelfitting/metric.py
+++ b/brian2modelfitting/metric.py
@@ -11,8 +11,8 @@ except ImportError:
 from itertools import repeat
 from brian2 import second, Quantity, ms, get_dimensions, mV
 from brian2.units.fundamentalunits import check_units, DIMENSIONLESS
-from numpy import (array, sum, abs, amin, digitize, rint, arange, inf, NaN,
-                   clip, mean)
+from numpy import (array, sum, abs, amin, digitize, rint, arange, inf,
+                   nan as NaN, clip, mean)
 
 
 def _check_efel():


### PR DESCRIPTION
This PR fixes an ImportError caused by the removal of `np.NaN` in newer NumPy versions.
I have aliased `nan as NaN` in `metric.py` to maintain backward compatibility while fixing the crash.